### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/vertx-hk2/pom.xml
+++ b/vertx-hk2/pom.xml
@@ -15,10 +15,7 @@
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.hk2</groupId>
-            <artifactId>hk2-locator</artifactId>
-        </dependency>
+        
     </dependencies>
 
 </project>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
vertx-hk2-parent
vertx-hk2
{groupId='org.glassfish.hk2', artifactId='hk2-locator'}
vertx-hk2-examples
vertx-hk2-simple
{groupId='org.mockito', artifactId='mockito-core'}
vertx-hk2-parent-locator
{groupId='org.mockito', artifactId='mockito-core'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
